### PR TITLE
Fix "IsVoid" anti-piracy detection

### DIFF
--- a/ModAssistant/Classes/Utils.cs
+++ b/ModAssistant/Classes/Utils.cs
@@ -385,14 +385,14 @@ namespace ModAssistant
         public static bool IsVoid()
         {
             string directory = App.BeatSaberInstallDirectory;
-            string pluginsDirectory = Path.Combine(directory, "Beat Saber_Data", "Plugins");
+            string pluginsDirectory = Path.Combine(directory, "Beat Saber_Data", "Plugins", "x86_64"); // newer version of bs use x86_64 for plugins folder
 
             if (File.Exists(Path.Combine(directory, "IGG-GAMES.COM.url")) ||
                 File.Exists(Path.Combine(directory, "SmartSteamEmu.ini")) ||
                 File.Exists(Path.Combine(directory, "GAMESTORRENT.CO.url")) ||
                 File.Exists(Path.Combine(pluginsDirectory, "BSteam crack.dll")) ||
                 File.Exists(Path.Combine(pluginsDirectory, "HUHUVR_steam_api64.dll")) ||
-                Directory.GetFiles(pluginsDirectory, "*.ini", SearchOption.TopDirectoryOnly).Where(x => Path.GetFileName(x) != "desktop.ini").Any())
+                Directory.GetFiles(pluginsDirectory, "*.ini", SearchOption.TopDirectoryOnly).Where(x => Path.GetFileName(x).ToLower() != "desktop.ini").Any())
                 return true;
             return false;
         }


### PR DESCRIPTION
This PR should fix two bugs:

- A recent(?) update to Beat Saber moved all native plugins into an x86_64 subdirectory, breaking ModAssistant's detection.

- Certain Windows systems will create an all-uppercase DESKTOP.INI file, causing false flags as ModAssistant previously only checked for lowercase desktop.ini.

(Also a note for the devs: have you considered removing the checks? It seems trivial to bypass, false flags can happen as not every ini is a keygen, and the company that owns Beat Saber is Facebook...)