### PR TITLE
Update ModAssistant repo for bsmg account

### DIFF
--- a/ModAssistant/Classes/Updater.cs
+++ b/ModAssistant/Classes/Updater.cs
@@ -9,7 +9,7 @@ namespace ModAssistant
 {
     class Updater
     {
-        private static readonly string APILatestURL = "https://api.github.com/repos/Assistant/ModAssistant/releases/latest";
+        private static readonly string APILatestURL = "https://api.github.com/repos/bsmg/ModAssistant/releases/latest";
 
         private static Update LatestUpdate;
         private static Version CurrentVersion;

--- a/ModAssistant/Localisation/cs.xaml
+++ b/ModAssistant/Localisation/cs.xaml
@@ -121,7 +121,7 @@
             stránku pro příspěvky
         </Hyperlink>
         nebo můj
-        <Hyperlink local:HyperlinkExtensions.IsExternal="True" NavigateUri="https://www.patreon.com/AssistantMoe">
+        <Hyperlink local:HyperlinkExtensions.IsExternal="True" NavigateUri="https://www.patreon.com/beatsabermods">
             Patreon
         </Hyperlink>
     </Span>

--- a/ModAssistant/Localisation/de.xaml
+++ b/ModAssistant/Localisation/de.xaml
@@ -121,7 +121,7 @@
             Spendenseite
         </Hyperlink>
          oder mein 
-        <Hyperlink local:HyperlinkExtensions.IsExternal="True" NavigateUri="https://www.patreon.com/AssistantMoe">
+        <Hyperlink local:HyperlinkExtensions.IsExternal="True" NavigateUri="https://www.patreon.com/beatsabermods">
             Patreon
         </Hyperlink>
     </Span>

--- a/ModAssistant/Localisation/en.xaml
+++ b/ModAssistant/Localisation/en.xaml
@@ -121,7 +121,7 @@
             donation page
         </Hyperlink>
         or the 
-        <Hyperlink local:HyperlinkExtensions.IsExternal="True" NavigateUri="https://www.patreon.com/AssistantMoe">
+        <Hyperlink local:HyperlinkExtensions.IsExternal="True" NavigateUri="https://www.patreon.com/beatsabermods">
             BSMG Patreon
         </Hyperlink>
     </Span>

--- a/ModAssistant/Localisation/en.xaml
+++ b/ModAssistant/Localisation/en.xaml
@@ -120,9 +120,9 @@
         <Hyperlink local:HyperlinkExtensions.IsExternal="True" NavigateUri="https://bs.assistant.moe/Donate/">
             donation page
         </Hyperlink>
-        or my
+        or the 
         <Hyperlink local:HyperlinkExtensions.IsExternal="True" NavigateUri="https://www.patreon.com/AssistantMoe">
-            Patreon
+            BSMG Patreon
         </Hyperlink>
     </Span>
     <sys:String x:Key="About:SpecialThanks">Special Thanks ♥</sys:String>

--- a/ModAssistant/Localisation/es.xaml
+++ b/ModAssistant/Localisation/es.xaml
@@ -120,7 +120,7 @@
             página de donación
         </Hyperlink>
         o mi
-        <Hyperlink local:HyperlinkExtensions.IsExternal="True" NavigateUri="https://www.patreon.com/AssistantMoe">
+        <Hyperlink local:HyperlinkExtensions.IsExternal="True" NavigateUri="https://www.patreon.com/beatsabermods">
             Patreon
         </Hyperlink>
     </Span>

--- a/ModAssistant/Localisation/fr.xaml
+++ b/ModAssistant/Localisation/fr.xaml
@@ -126,7 +126,7 @@
             page de don
         </Hyperlink>
         ou mon
-        <Hyperlink local:HyperlinkExtensions.IsExternal="True" NavigateUri="https://www.patreon.com/AssistantMoe">
+        <Hyperlink local:HyperlinkExtensions.IsExternal="True" NavigateUri="https://www.patreon.com/beatsabermods">
             Patreon
         </Hyperlink>
     </Span>

--- a/ModAssistant/Localisation/it.xaml
+++ b/ModAssistant/Localisation/it.xaml
@@ -121,7 +121,7 @@
             pagina delle donazioni
         </Hyperlink>
         oppure il mio 
-        <Hyperlink local:HyperlinkExtensions.IsExternal="True" NavigateUri="https://www.patreon.com/AssistantMoe">
+        <Hyperlink local:HyperlinkExtensions.IsExternal="True" NavigateUri="https://www.patreon.com/beatsabermods">
             Patreon
         </Hyperlink>
     </Span>

--- a/ModAssistant/Localisation/ja.xaml
+++ b/ModAssistant/Localisation/ja.xaml
@@ -120,7 +120,7 @@
             寄付ページ
         </Hyperlink>
         または私の
-        <Hyperlink local:HyperlinkExtensions.IsExternal="True" NavigateUri="https://www.patreon.com/AssistantMoe">
+        <Hyperlink local:HyperlinkExtensions.IsExternal="True" NavigateUri="https://www.patreon.com/beatsabermods">
             Patreon
         </Hyperlink> を訪れてください。
     </Span>

--- a/ModAssistant/Localisation/ko.xaml
+++ b/ModAssistant/Localisation/ko.xaml
@@ -120,7 +120,7 @@
             donation page
         </Hyperlink>
         or my
-        <Hyperlink local:HyperlinkExtensions.IsExternal="True" NavigateUri="https://www.patreon.com/AssistantMoe">
+        <Hyperlink local:HyperlinkExtensions.IsExternal="True" NavigateUri="https://www.patreon.com/beatsabermods">
             Patreon
         </Hyperlink>
     </Span>

--- a/ModAssistant/Localisation/nb.xaml
+++ b/ModAssistant/Localisation/nb.xaml
@@ -124,7 +124,7 @@
             donasjonsside
         </Hyperlink>
         eller min
-        <Hyperlink local:HyperlinkExtensions.IsExternal="True" NavigateUri="https://www.patreon.com/AssistantMoe">
+        <Hyperlink local:HyperlinkExtensions.IsExternal="True" NavigateUri="https://www.patreon.com/beatsabermods">
             Patreon
         </Hyperlink>
     </Span>

--- a/ModAssistant/Localisation/nl.xaml
+++ b/ModAssistant/Localisation/nl.xaml
@@ -119,7 +119,7 @@
             donatie pagina
         </Hyperlink>
         of mijn
-        <Hyperlink local:HyperlinkExtensions.IsExternal="True" NavigateUri="https://www.patreon.com/AssistantMoe">
+        <Hyperlink local:HyperlinkExtensions.IsExternal="True" NavigateUri="https://www.patreon.com/beatsabermods">
             Patreon
         </Hyperlink>
     </Span>

--- a/ModAssistant/Localisation/pl.xaml
+++ b/ModAssistant/Localisation/pl.xaml
@@ -121,7 +121,7 @@
             stronę dotacji
         </Hyperlink>
         lub mojego
-        <Hyperlink local:HyperlinkExtensions.IsExternal="True" NavigateUri="https://www.patreon.com/AssistantMoe">
+        <Hyperlink local:HyperlinkExtensions.IsExternal="True" NavigateUri="https://www.patreon.com/beatsabermods">
             Patreon'a
         </Hyperlink>
     </Span>

--- a/ModAssistant/Localisation/pt.xaml
+++ b/ModAssistant/Localisation/pt.xaml
@@ -121,7 +121,7 @@
            página de doação
         </Hyperlink>
         ou meu
-        <Hyperlink local:HyperlinkExtensions.IsExternal="True" NavigateUri="https://www.patreon.com/AssistantMoe">
+        <Hyperlink local:HyperlinkExtensions.IsExternal="True" NavigateUri="https://www.patreon.com/beatsabermods">
             Patreon
         </Hyperlink>
     </Span>

--- a/ModAssistant/Localisation/ru.xaml
+++ b/ModAssistant/Localisation/ru.xaml
@@ -121,7 +121,7 @@
             страницу для пожертвований 
         </Hyperlink>
         или мой
-        <Hyperlink local:HyperlinkExtensions.IsExternal="True" NavigateUri="https://www.patreon.com/AssistantMoe">
+        <Hyperlink local:HyperlinkExtensions.IsExternal="True" NavigateUri="https://www.patreon.com/beatsabermods">
             Patreon
         </Hyperlink>
     </Span>

--- a/ModAssistant/Localisation/sv.xaml
+++ b/ModAssistant/Localisation/sv.xaml
@@ -121,7 +121,7 @@
             donationssida
         </Hyperlink>
         eller min
-        <Hyperlink local:HyperlinkExtensions.IsExternal="True" NavigateUri="https://www.patreon.com/AssistantMoe">
+        <Hyperlink local:HyperlinkExtensions.IsExternal="True" NavigateUri="https://www.patreon.com/beatsabermods">
             Patreon
         </Hyperlink>
     </Span>

--- a/ModAssistant/Localisation/th.xaml
+++ b/ModAssistant/Localisation/th.xaml
@@ -121,7 +121,7 @@
             หน้าบริจาคของฉัน
         </Hyperlink>
         หรือ
-        <Hyperlink local:HyperlinkExtensions.IsExternal="True" NavigateUri="https://www.patreon.com/AssistantMoe">
+        <Hyperlink local:HyperlinkExtensions.IsExternal="True" NavigateUri="https://www.patreon.com/beatsabermods">
             หน้า Patreon ของฉัน
         </Hyperlink>
     </Span>

--- a/ModAssistant/Localisation/zh.xaml
+++ b/ModAssistant/Localisation/zh.xaml
@@ -120,7 +120,7 @@
             捐助页面
         </Hyperlink>
         或我的
-        <Hyperlink local:HyperlinkExtensions.IsExternal="True" NavigateUri="https://www.patreon.com/AssistantMoe">
+        <Hyperlink local:HyperlinkExtensions.IsExternal="True" NavigateUri="https://www.patreon.com/beatsabermods">
             Patreon
         </Hyperlink>
     </Span>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Mod Assistant](https://cdn.assistant.moe/images/ModAssistant/Icons/Banner.svg?v=5)](https://github.com/Assistant/ModAssistant/releases/latest)
-[![Download here!](https://cdn.assistant.moe/images/ModAssistant/Icons/Download.svg)](https://github.com/Assistant/ModAssistant/releases/latest)
+[![Mod Assistant](https://cdn.assistant.moe/images/ModAssistant/Icons/Banner.svg?v=5)](https://github.com/bsmg/ModAssistant/releases/latest)
+[![Download here!](https://cdn.assistant.moe/images/ModAssistant/Icons/Download.svg)](https://github.com/bsmg/ModAssistant/releases/latest)
 
 Mod Assistant is a PC mod installer for Beat Saber. It uses mods from [BeatMods](https://beatmods.com/).
 
@@ -90,7 +90,7 @@ Custom themes are located in a folder called `Themes` in the same folder as `Mod
 ### Built In
 These come with the program and you can't change them, however you can overwrite them by creating one of the other two theme types with the same name.
 
-If you have a particularly popular theme, you can submit a [Pull Request](https://github.com/Assistant/ModAssistant/pulls) to add your theme as a built-in theme.
+If you have a particularly popular theme, you can submit a [Pull Request](https://github.com/bsmg/ModAssistant/pulls) to add your theme as a built-in theme.
 
 ### Packaged `.mat` Files
 These are pre-packaged theme files. Under the hood they are renamed`.zip` files, and the file structure is the same as that of `Folders` themes. These will be overwritten by `Folders` themes with the same name. 


### PR DESCRIPTION
- Changes the update check URL to use `bsmg` now that ModAssistant is under the bsmg account.
- Fixed any links within the README to point to the `bsmg` repo
- Fixed the Patreon link in the About page. Patreon was already redirecting it automatically anyway.

The updater seemed to work using the old URL, but future releases (if any) need to pull from the correct repo.
For sanity I double checked the downloader by forcing the app version lower, and the app is capable of downloading the latest release from the bsmg repo.

I had to make a different PR to change the README images to make sure they were hosted under the bsmg account instead of my account. #529 